### PR TITLE
Feature: radarChance of aircraft's radars.

### DIFF
--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -1312,7 +1312,7 @@ void GeoscapeState::time30Minutes()
 					}
 					for (std::vector<Craft*>::iterator c = (*b)->getCrafts()->begin(); !detected && c != (*b)->getCrafts()->end(); ++c)
 					{
-						if ((*c)->getStatus() == "STR_OUT" && (*c)->detect(*u))
+						if ((*c)->getStatus() == "STR_OUT" && (*c)->insideRadarRange(*u))
 						{
 							detected = true;
 							hyperdetected = (*u)->getHyperDetected();

--- a/src/Ruleset/RuleCraft.cpp
+++ b/src/Ruleset/RuleCraft.cpp
@@ -30,9 +30,9 @@ namespace OpenXcom
 RuleCraft::RuleCraft(const std::string &type) :
     _type(type), _sprite(-1), _fuelMax(0), _damageMax(0), _speedMax(0), _accel(0),
     _weapons(0), _soldiers(0), _vehicles(0), _costBuy(0), _costRent(0), _costSell(0),
-	_refuelItem(""), _repairRate(1), _refuelRate(1), _radarRange(672), _sightRange(1696),
-	_transferTime(0), _score(0), _battlescapeTerrainData(0), _spacecraft(false),
-	_listOrder(0), _maxItems(0)
+	_refuelItem(""), _repairRate(1), _refuelRate(1), _radarRange(672), _radarChance(100),
+	_sightRange(1696), _transferTime(0), _score(0), _battlescapeTerrainData(0),
+	_spacecraft(false), _listOrder(0), _maxItems(0)
 {
 
 }
@@ -77,6 +77,7 @@ void RuleCraft::load(const YAML::Node &node, Ruleset *ruleset, int modIndex, int
 	_repairRate = node["repairRate"].as<int>(_repairRate);
 	_refuelRate = node["refuelRate"].as<int>(_refuelRate);
 	_radarRange = node["radarRange"].as<int>(_radarRange);
+	_radarChance = node["radarChance"].as<int>(_radarChance);
 	_sightRange = node["sightRange"].as<int>(_sightRange);
 	_transferTime = node["transferTime"].as<int>(_transferTime);
 	_score = node["score"].as<int>(_score);

--- a/src/Ruleset/RuleCraft.h
+++ b/src/Ruleset/RuleCraft.h
@@ -43,7 +43,7 @@ private:
 	int _sprite;
 	int _fuelMax, _damageMax, _speedMax, _accel, _weapons, _soldiers, _vehicles, _costBuy, _costRent, _costSell;
 	std::string _refuelItem;
-	int _repairRate, _refuelRate, _radarRange, _sightRange, _transferTime, _score;
+	int _repairRate, _refuelRate, _radarRange, _radarChance, _sightRange, _transferTime, _score;
 	RuleTerrain *_battlescapeTerrainData;
 	bool _spacecraft;
 	int _listOrder, _maxItems;
@@ -89,6 +89,8 @@ public:
 	int getRefuelRate() const;
 	/// Gets the craft's radar range.
 	int getRadarRange() const;
+	/// Gets the craft's radar chance.
+	inline int getRadarChance() const {return _radarChance;}
 	/// Gets the craft's sight range.
 	int getSightRange() const;
 	/// Gets the craft's transfer time.

--- a/src/Savegame/Craft.cpp
+++ b/src/Savegame/Craft.cpp
@@ -21,6 +21,7 @@
 #include <cmath>
 #include <sstream>
 #include "../Engine/Language.h"
+#include "../Engine/RNG.h"
 #include "../Ruleset/RuleCraft.h"
 #include "CraftWeapon.h"
 #include "../Ruleset/RuleCraftWeapon.h"
@@ -714,8 +715,26 @@ void Craft::checkup()
  */
 bool Craft::detect(Target *target) const
 {
-	if (_rules->getRadarRange() == 0)
+	if (_rules->getRadarRange() == 0 || !insideRadarRange(target))
 		return false;
+
+	// backward compatibility with vanilla
+	if (_rules->getRadarChance() == 100)
+		return true;
+
+	Ufo *u = dynamic_cast<Ufo*>(target);
+	int chance = _rules->getRadarChance() * (100 + u->getVisibility()) / 100;
+	return RNG::percent(chance);
+}
+
+/**
+ * Returns if a certain target is inside the craft's
+ * radar range, taking in account the positions of both.
+ * @param target Pointer to target to compare.
+ * @return True if inside radar range.
+ */
+bool Craft::insideRadarRange(Target *target) const
+{
 	double range = _rules->getRadarRange() * (1 / 60.0) * (M_PI / 180);
 	return (getDistance(target) <= range);
 }

--- a/src/Savegame/Craft.h
+++ b/src/Savegame/Craft.h
@@ -132,6 +132,8 @@ public:
 	void returnToBase();
 	/// Checks if a target is detected by the craft's radar.
 	bool detect(Target *target) const;
+	/// Checks if a target is inside the craft's radar range.
+	bool insideRadarRange(Target *target) const;
 	/// Handles craft logic.
 	void think();
 	/// Does a craft full checkup.


### PR DESCRIPTION
Added the rule "radarChance" to radars of crafts. Default 100 of course.
For calculation of UFO detection uses the same rule as for conventional (underground ;-)) radars.

Useful use case is AWACS aircraft.
