### PR TITLE
Workaround: personal lighting not taken into account in visible() calc.

### DIFF
--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -415,7 +415,8 @@ bool TileEngine::visible(BattleUnit *currentUnit, Tile *tile)
 	// aliens can see in the dark at least 20 tiles, xcom can see at a distance of 9 (MaxViewDistanceAtDark) or less, further if there's enough light.
 	if (getMaxViewDistanceSq() > currentUnit->getMaxViewDistanceAtDarkSq() &&
 		distanceSq(currentUnit->getPosition(), tile->getPosition(), false) > currentUnit->getMaxViewDistanceAtDarkSq() &&
-		tile->getShade() > getMaxDarknessToSeeUnits())
+		tile->getExternalShade() > getMaxDarknessToSeeUnits() &&
+		tile->getUnit()->getFire() == 0)
 	{
 		return false;
 	}

--- a/src/Savegame/Tile.cpp
+++ b/src/Savegame/Tile.cpp
@@ -436,6 +436,26 @@ int Tile::getShade() const
 }
 
 /**
+ * Gets the tile's shade amount 0-15. It returns the brightest of all light layers except 2th (dynamic) layer.
+ * Shade level is the inverse of light level. So a maximum amount of light (15) returns shade level 0.
+ * @return shade
+ */
+int Tile::getExternalShade() const
+{
+	int light = 0;
+	// 2th layer (dynamic) not taken into account
+	for (int layer = 0; layer < LIGHTLAYERS; layer++)
+	{
+		if (layer == 2) continue;
+
+		if (_light[layer] > light)
+			light = _light[layer];
+	}
+
+	return std::max(0, 15 - light);
+}
+
+/**
  * Destroy a part on this tile. We first remove the old object, then replace it with the destroyed one.
  * This is because the object type of the old and new one are not necessarily the same.
  * If the destroyed part is an explosive, set the tile's explosive value, which will trigger a chained explosion.

--- a/src/Savegame/Tile.h
+++ b/src/Savegame/Tile.h
@@ -158,6 +158,8 @@ public:
 	void addLight(int light, int layer);
 	/// Get the shade amount.
 	int getShade() const;
+	/// Get the shade amount except 2th (dynamic) layer.
+	int getExternalShade() const;
 	/// Destroy a tile part.
 	bool destroy(int part);
 	/// Damage a tile part.


### PR DESCRIPTION
Workaround: personal lighting (dynamic light) not taken into account in visible() calculation.
All other light sources (sun and static light) will work as before. Static light: flame, electro flares, lamps, static objects with light sources.

If unit in fire (not terrain, only unit), then this fire taken into account too. This fire was a part of dynamic light.
