### PR TITLE
Feature: Show crosshair when throwing

### DIFF
--- a/bin/data/Language/en-GB.yml
+++ b/bin/data/Language/en-GB.yml
@@ -1184,6 +1184,8 @@ en-GB:
   STR_ALLOWPSISTRENGTHIMPROVEMENT_DESC: "Psionic strength of the soldiers can be improved by experience and training."
   STR_TFTDDAMAGE: "TFTD Damage Formula"
   STR_TFTDDAMAGE_DESC: "Weapons will do between 50% and 150% of their rated damage as opposed to UFO: Enemy Unknown's 0% to 200%"
+  STR_BATTLESHOWTHROWCROSSHAIR: "Show crosshair when throwing"
+  STR_BATTLESHOWTHROWCROSSHAIR_DESC: "When use grenade will be shown an area, affected by explosion."
   STR_BATTLESMOOTHCAMERA: "Smooth Bullet Camera"
   STR_BATTLESMOOTHCAMERA_DESC: "The Battlescape camera will remain centred on projectiles while in flight."
   STR_BATTLECONFIRMFIREMODE: "Confirm Fire mode"

--- a/bin/data/Language/en-US.yml
+++ b/bin/data/Language/en-US.yml
@@ -1184,6 +1184,8 @@ en-US:
   STR_ALLOWPSISTRENGTHIMPROVEMENT_DESC: "Psionic strength of the soldiers can be improved by experience and training."
   STR_TFTDDAMAGE: "TFTD Damage Formula"
   STR_TFTDDAMAGE_DESC: "Weapons will do between 50% and 150% of their rated damage as opposed to X-COM: UFO Defense's 0% to 200%"
+  STR_BATTLESHOWTHROWCROSSHAIR: "Show crosshair when throwing"
+  STR_BATTLESHOWTHROWCROSSHAIR_DESC: "When use grenade will be shown an area, affected by explosion."
   STR_BATTLESMOOTHCAMERA: "Smooth Bullet Camera"
   STR_BATTLESMOOTHCAMERA_DESC: "The Battlescape camera will remain centered on projectiles while in flight."
   STR_BATTLECONFIRMFIREMODE: "Confirm Fire mode"

--- a/src/Battlescape/Map.h
+++ b/src/Battlescape/Map.h
@@ -27,7 +27,7 @@
 
 namespace OpenXcom
 {
-
+struct BattleAction;
 class ResourcePack;
 class SavedBattleGame;
 class Surface;
@@ -53,7 +53,7 @@ private:
 	Game *_game;
 	SavedBattleGame *_save;
 	ResourcePack *_res;
-	Surface *_arrow;
+	Surface *_arrow, *_throwCrosshair, *_throwFrame;
 	int _spriteWidth, _spriteHeight;
 	int _selectorX, _selectorY;
 	int _mouseX, _mouseY;
@@ -77,6 +77,11 @@ private:
 	int getTerrainLevel(Position pos, int size);
 	int _iconHeight, _iconWidth, _messageColor;
 	const std::vector<Uint8> *_transparencies;
+
+	/// Drawing blast radius.
+	bool drawBlastRadius(const BattleAction& action);
+	/// Clipping left and right corners.
+	static void clipCorners(Surface *surface);
 public:
 	/// Creates a new map at the specified position and size.
 	Map(Game* game, int width, int height, int x, int y, int visibleMapHeight);

--- a/src/Battlescape/Projectile.cpp
+++ b/src/Battlescape/Projectile.cpp
@@ -210,9 +210,10 @@ int Projectile::calculateTrajectory(double accuracy, Position originVoxel)
 /**
  * Calculates the trajectory for a curved path.
  * @param accuracy The unit's accuracy.
+ * @param doTestTrajectory
  * @return True when a trajectory is possible.
  */
-int Projectile::calculateThrow(double accuracy)
+int Projectile::calculateThrow(double accuracy, bool doTestTrajectory)
 {
 	Tile *targetTile = _save->getTile(_action.target);
 
@@ -235,6 +236,11 @@ int Projectile::calculateThrow(double accuracy)
 	int retVal = V_OUTOFBOUNDS;
 	if (_save->getTileEngine()->validateThrow(_action, originVoxel, targetVoxel, &curvature, &retVal))
 	{
+		if (doTestTrajectory)
+		{
+			return V_FLOOR;	// retVal;
+		}
+
 		int test = V_OUTOFBOUNDS;
 		// finally do a line calculation and store this trajectory, make sure it's valid.
 		while (test == V_OUTOFBOUNDS)

--- a/src/Battlescape/Projectile.h
+++ b/src/Battlescape/Projectile.h
@@ -61,7 +61,7 @@ public:
 	int calculateTrajectory(double accuracy);
 	int calculateTrajectory(double accuracy, Position originVoxel);
 	/// Calculates the trajectory for a curved path.
-	int calculateThrow(double accuracy);
+	int calculateThrow(double accuracy, bool doTestTrajectory = false);
 	/// Moves the projectile one step in its trajectory.
 	bool move();
 	/// Gets the current position in voxel space.

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -181,6 +181,7 @@ void create()
 	_info.push_back(OptionInfo("includePrimeStateInSavedLayout", &includePrimeStateInSavedLayout, false, "STR_INCLUDE_PRIMESTATE_IN_SAVED_LAYOUT", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo("battleExplosionHeight", &battleExplosionHeight, 0, "STR_BATTLEEXPLOSIONHEIGHT", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo("battleAutoEnd", &battleAutoEnd, false, "STR_BATTLEAUTOEND", "STR_BATTLESCAPE"));
+	_info.push_back(OptionInfo("battleShowThrowCrosshair", &battleShowThrowCrosshair, false, "STR_BATTLESHOWTHROWCROSSHAIR", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo("battleSmoothCamera", &battleSmoothCamera, false, "STR_BATTLESMOOTHCAMERA", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo("disableAutoEquip", &disableAutoEquip, false, "STR_DISABLEAUTOEQUIP", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo("battleConfirmFireMode", &battleConfirmFireMode, false, "STR_BATTLECONFIRMFIREMODE", "STR_BATTLESCAPE"));

--- a/src/Engine/Options.inc.h
+++ b/src/Engine/Options.inc.h
@@ -30,7 +30,7 @@ OPT ScrollType battleEdgeScroll;
 OPT PathPreview battleNewPreviewPath;
 OPT int battleScrollSpeed, battleDragScrollButton, battleFireSpeed, battleXcomSpeed, battleAlienSpeed, battleExplosionHeight, battlescapeScale;
 OPT bool traceAI, sneakyAI, battleInstantGrenade, battleNotifyDeath, battleTooltips, battleHairBleach, battleAutoEnd,
-	strafe, forceFire, showMoreStatsInInventoryView, allowPsionicCapture, skipNextTurnScreen, disableAutoEquip, battleDragScrollInvert,
+	strafe, forceFire, showMoreStatsInInventoryView, allowPsionicCapture, skipNextTurnScreen, disableAutoEquip, battleDragScrollInvert, battleShowThrowCrosshair,
 	battleUFOExtenderAccuracy, battleConfirmFireMode, battleSmoothCamera, TFTDDamage, noAlienPanicMessages, alienBleeding;
 OPT SDLKey keyBattleLeft, keyBattleRight, keyBattleUp, keyBattleDown, keyBattleLevelUp, keyBattleLevelDown, keyBattleCenterUnit, keyBattlePrevUnit, keyBattleNextUnit, keyBattleDeselectUnit,
 	keyBattleUseLeftHand, keyBattleUseRightHand, keyBattleInventory, keyBattleMap, keyBattleOptions, keyBattleEndTurn, keyBattleAbort, keyBattleStats, keyBattleKneel,

--- a/src/Engine/Surface.cpp
+++ b/src/Engine/Surface.cpp
@@ -612,6 +612,19 @@ void Surface::drawCircle(Sint16 x, Sint16 y, Sint16 r, Uint8 color)
 }
 
 /**
+ * Draws a filled ellipse on the surface.
+ * @param x X coordinate in pixels.
+ * @param y Y coordinate in pixels.
+ * @param rx Radius in pixels on X axis.
+ * @param ry Radius in pixels on Y axis.
+ * @param color Color of the circle.
+ */
+void Surface::drawEllipse(Sint16 x, Sint16 y, Sint16 rx, Sint16 ry, Uint8 color)
+{
+	filledEllipseColor(_surface, x, y, rx, ry, Palette::getRGBA(getPalette(), color));
+}
+
+/**
  * Draws a filled polygon on the surface.
  * @param x Array of x coordinates.
  * @param y Array of y coordinates.

--- a/src/Engine/Surface.h
+++ b/src/Engine/Surface.h
@@ -86,7 +86,9 @@ public:
     void drawLine(Sint16 x1, Sint16 y1, Sint16 x2, Sint16 y2, Uint8 color);
     /// Draws a filled circle on the surface.
     void drawCircle(Sint16 x, Sint16 y, Sint16 r, Uint8 color);
-    /// Draws a filled polygon on the surface.
+	/// Draws a filled ellipse on the surface.
+	void drawEllipse(Sint16 x, Sint16 y, Sint16 rx, Sint16 ry, Uint8 color);
+	/// Draws a filled polygon on the surface.
     void drawPolygon(Sint16 *x, Sint16 *y, int n, Uint8 color);
     /// Draws a textured polygon on the surface.
     void drawTexturedPolygon(Sint16 *x, Sint16 *y, int n, Surface *texture, int dx, int dy);


### PR DESCRIPTION
This is reworked variant of the option. Removed at least half unnecessary code:)
Crosshair when throwing to the free space:
![screen024_640](https://cloud.githubusercontent.com/assets/3616568/6885378/a0709aa8-d626-11e4-9bfa-f147866086da.png)

If visible units will be in affected area, the crosshair will be flashing:
![screen025_640](https://cloud.githubusercontent.com/assets/3616568/6885380/a86447c8-d626-11e4-928a-fb59cde744bd.png)

Disadvantage (because OXE not use language files):
![screen004](https://cloud.githubusercontent.com/assets/3616568/6885395/42c0e736-d627-11e4-86dd-0a5e2197de45.png)

But, maybe, this is advantage, because will attract attention of players:)