### PR TITLE
Feature: Locations of enemies, uncovered by scanner, will be marked as red boxes

### DIFF
--- a/bin/data/Language/en-GB.yml
+++ b/bin/data/Language/en-GB.yml
@@ -1186,6 +1186,8 @@ en-GB:
   STR_TFTDDAMAGE_DESC: "Weapons will do between 50% and 150% of their rated damage as opposed to UFO: Enemy Unknown's 0% to 200%"
   STR_BATTLESMOOTHCAMERA: "Smooth Bullet Camera"
   STR_BATTLESMOOTHCAMERA_DESC: "The Battlescape camera will remain centred on projectiles while in flight."
+  STR_BATTLEADVANCEDSCANNER: "Advanced motion scanner"
+  STR_BATTLEADVANCEDSCANNER_DESC: "Locations of enemies, uncovered by scanner, will be marked as red boxes on the battlefield."
   STR_BATTLECONFIRMFIREMODE: "Confirm Fire mode"
   STR_BATTLECONFIRMFIREMODE_DESC: "Require a second click on the same tile to confirm fire orders."
   STR_SELECT_BASE_1: "Select Base 1"

--- a/bin/data/Language/en-US.yml
+++ b/bin/data/Language/en-US.yml
@@ -1186,6 +1186,8 @@ en-US:
   STR_TFTDDAMAGE_DESC: "Weapons will do between 50% and 150% of their rated damage as opposed to X-COM: UFO Defense's 0% to 200%"
   STR_BATTLESMOOTHCAMERA: "Smooth Bullet Camera"
   STR_BATTLESMOOTHCAMERA_DESC: "The Battlescape camera will remain centered on projectiles while in flight."
+  STR_BATTLEADVANCEDSCANNER: "Advanced motion scanner"
+  STR_BATTLEADVANCEDSCANNER_DESC: "Locations of enemies, uncovered by scanner, will be marked as red boxes on the battlefield."
   STR_BATTLECONFIRMFIREMODE: "Confirm Fire mode"
   STR_BATTLECONFIRMFIREMODE_DESC: "Require a second click on the same tile to confirm fire orders."
   STR_SELECT_BASE_1: "Select Base 1"

--- a/src/Battlescape/Map.cpp
+++ b/src/Battlescape/Map.cpp
@@ -979,6 +979,16 @@ void Map::drawTerrain(Surface *surface)
 								tmpSurface->blitNShade(surface, screenPosition.x, screenPosition.y - tile->getMapData(MapData::O_OBJECT)->getYOffset(), tileShade, false);
 						}
 					}
+					// Draw a box around scanned unit
+					if (Options::battleAdvancedScanner && unit && unit->getScannedTurn() == _save->getTurn() &&
+						_save->getSide() == FACTION_PLAYER && !unit->getVisible() &&
+						!(_selectorX == itX && _selectorY == itY && _camera->getViewLevel() >= itZ))
+					{
+							tmpSurface = _res->getSurfaceSet("CURSOR.PCK")->getFrame(0);	// back of red box
+							tmpSurface->blitNShade(surface, screenPosition.x, screenPosition.y, 0);
+							tmpSurface = _res->getSurfaceSet("CURSOR.PCK")->getFrame(3);	// front of red box
+							tmpSurface->blitNShade(surface, screenPosition.x, screenPosition.y, 0);
+					}
 					// Draw cursor front
 					if (_cursorType != CT_NONE && _selectorX > itX - _cursorSize && _selectorY > itY - _cursorSize && _selectorX < itX+1 && _selectorY < itY+1 && !_save->getBattleState()->getMouseOverIcons())
 					{

--- a/src/Battlescape/ScannerView.cpp
+++ b/src/Battlescape/ScannerView.cpp
@@ -67,6 +67,7 @@ void ScannerView::draw()
 					int frame = (t->getUnit()->getMotionPoints() / 5);
 					if (frame >= 0)
 					{
+						t->getUnit()->setScannedTurn(_game->getSavedGame()->getSavedBattle()->getTurn());
 						if (frame > 5) frame = 5;
 						surface = set->getFrame(frame + _frame);
 						surface->blitNShade(this, Surface::getX()+((9+x)*8)-4, Surface::getY()+((9+y)*8)-4, 0);

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -182,6 +182,7 @@ void create()
 	_info.push_back(OptionInfo("battleExplosionHeight", &battleExplosionHeight, 0, "STR_BATTLEEXPLOSIONHEIGHT", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo("battleAutoEnd", &battleAutoEnd, false, "STR_BATTLEAUTOEND", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo("battleSmoothCamera", &battleSmoothCamera, false, "STR_BATTLESMOOTHCAMERA", "STR_BATTLESCAPE"));
+	_info.push_back(OptionInfo("battleAdvancedScanner", &battleAdvancedScanner, false, "STR_BATTLEADVANCEDSCANNER", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo("disableAutoEquip", &disableAutoEquip, false, "STR_DISABLEAUTOEQUIP", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo("battleConfirmFireMode", &battleConfirmFireMode, false, "STR_BATTLECONFIRMFIREMODE", "STR_BATTLESCAPE"));
 	_info.push_back(OptionInfo("weaponSelfDestruction", &weaponSelfDestruction, false, "STR_WEAPONSELFDESTRUCTION", "STR_BATTLESCAPE"));

--- a/src/Engine/Options.inc.h
+++ b/src/Engine/Options.inc.h
@@ -31,7 +31,7 @@ OPT PathPreview battleNewPreviewPath;
 OPT int battleScrollSpeed, battleDragScrollButton, battleFireSpeed, battleXcomSpeed, battleAlienSpeed, battleExplosionHeight, battlescapeScale;
 OPT bool traceAI, sneakyAI, battleInstantGrenade, battleNotifyDeath, battleTooltips, battleHairBleach, battleAutoEnd,
 	strafe, forceFire, showMoreStatsInInventoryView, allowPsionicCapture, skipNextTurnScreen, disableAutoEquip, battleDragScrollInvert,
-	battleUFOExtenderAccuracy, battleConfirmFireMode, battleSmoothCamera, TFTDDamage, noAlienPanicMessages, alienBleeding;
+	battleUFOExtenderAccuracy, battleConfirmFireMode, battleSmoothCamera, battleAdvancedScanner, TFTDDamage, noAlienPanicMessages, alienBleeding;
 OPT SDLKey keyBattleLeft, keyBattleRight, keyBattleUp, keyBattleDown, keyBattleLevelUp, keyBattleLevelDown, keyBattleCenterUnit, keyBattlePrevUnit, keyBattleNextUnit, keyBattleDeselectUnit,
 	keyBattleUseLeftHand, keyBattleUseRightHand, keyBattleInventory, keyBattleMap, keyBattleOptions, keyBattleEndTurn, keyBattleAbort, keyBattleStats, keyBattleKneel,
 	keyBattleReserveKneel, keyBattleReload, keyBattlePersonalLighting, keyBattleReserveNone, keyBattleReserveSnap, keyBattleReserveAimed, keyBattleReserveAuto,

--- a/src/Savegame/BattleUnit.cpp
+++ b/src/Savegame/BattleUnit.cpp
@@ -56,7 +56,7 @@ BattleUnit::BattleUnit(Soldier *soldier, int depth) :
 	_verticalDirection(0), _status(STATUS_STANDING), _walkPhase(0), _fallPhase(0), _kneeled(false), _floating(false),
 	_dontReselect(false), _fire(0), _currentAIState(0), _visible(false), _cacheInvalid(true),
 	_expBravery(0), _expReactions(0), _expFiring(0), _expThrowing(0), _expPsiSkill(0), _expPsiStrength(0), _expMelee(0),
-	_motionPoints(0), _kills(0), _hitByFire(false), _fireMaxHit(0), _smokeMaxHit(0), _moraleRestored(0), _coverReserve(0), _charging(0),
+	_motionPoints(0), _scannedTurn(-1), _kills(0), _hitByFire(false), _fireMaxHit(0), _smokeMaxHit(0), _moraleRestored(0), _coverReserve(0), _charging(0),
 	_turnsSinceSpotted(255), _geoscapeSoldier(soldier), _unitRules(0), _rankInt(-1), _turretType(-1), _hidingForTurn(false), _respawn(false)
 {
 	_name = soldier->getName(true);
@@ -151,7 +151,7 @@ BattleUnit::BattleUnit(Unit *unit, UnitFaction faction, int id, Armor *armor, in
 	_toDirectionTurret(0),  _verticalDirection(0), _status(STATUS_STANDING), _walkPhase(0),
 	_fallPhase(0), _kneeled(false), _floating(false), _dontReselect(false), _fire(0), _currentAIState(0),
 	_visible(false), _cacheInvalid(true), _expBravery(0), _expReactions(0), _expFiring(0),
-	_expThrowing(0), _expPsiSkill(0), _expPsiStrength(0), _expMelee(0), _motionPoints(0), _kills(0), _hitByFire(false), _fireMaxHit(0), _smokeMaxHit(0),
+	_expThrowing(0), _expPsiSkill(0), _expPsiStrength(0), _expMelee(0), _motionPoints(0), _scannedTurn(-1), _kills(0), _hitByFire(false), _fireMaxHit(0), _smokeMaxHit(0),
 	_moraleRestored(0), _coverReserve(0), _charging(0), _turnsSinceSpotted(255),
 	_armor(armor), _geoscapeSoldier(0),  _unitRules(unit), _rankInt(-1),
 	_turretType(-1), _hidingForTurn(false), _respawn(false)

--- a/src/Savegame/BattleUnit.h
+++ b/src/Savegame/BattleUnit.h
@@ -89,6 +89,7 @@ private:
 	int _expBravery, _expReactions, _expFiring, _expThrowing, _expPsiSkill, _expPsiStrength, _expMelee;
 	int improveStat(int exp);
 	int _motionPoints;
+	int _scannedTurn;
 	int _kills;
 	int _faceDirection; // used only during strafeing moves
 	bool _hitByFire;
@@ -344,6 +345,10 @@ public:
 	void stimulant (int energy, int stun);
 	/// Get motion points for the motion scanner.
 	int getMotionPoints() const;
+	/// Get turn when unit was scanned by the motion scanner.
+	int getScannedTurn() const     {return _scannedTurn;}
+	/// Set turn when unit was scanned by the motion scanner.
+	void setScannedTurn(int turn)  {_scannedTurn = turn;}
 	/// Gets the unit's armor.
 	Armor *getArmor() const;
 	/// Gets the unit's name.


### PR DESCRIPTION
Somewhere on the forum I read about this idea.
Scanner rarely used because its use is too slow for a typical Xcom battle.
This feature allows greatly speed up and simplify use of scanner.

The _scannedTurn field not saved by design, because this red boxes is not a property of the battlefield or units, but it's just a helper for scanner usage.

Situation on the battlefield:
![screen013_640](https://cloud.githubusercontent.com/assets/3616568/6885403/fe005702-d627-11e4-8a41-4144f9d80e21.png)

Use the scanner:
![screen014_640](https://cloud.githubusercontent.com/assets/3616568/6885404/14c2468a-d628-11e4-92fa-b3d9f7f4a266.png)

Locations of detected enemies marked as red boxes:
![screen015_640](https://cloud.githubusercontent.com/assets/3616568/6885407/2b1c7798-d628-11e4-967a-177a0c6c1dc8.png)

One step forward. Visible units not marked as red blocks:
![screen016_640](https://cloud.githubusercontent.com/assets/3616568/6885417/76b10430-d628-11e4-9d70-b37da769ad2e.png)

Sectoid killed. New use of scanner:
![screen017_640](https://cloud.githubusercontent.com/assets/3616568/6885426/9e8564a6-d628-11e4-8f21-620c41ed196f.png)

One new target is my soldier, next one is new enemy:
![screen018_640](https://cloud.githubusercontent.com/assets/3616568/6885431/b7734e06-d628-11e4-9d45-d5157bcd70d4.png)

Location of new enemy:
![screen019_640](https://cloud.githubusercontent.com/assets/3616568/6885437/eb9b0912-d628-11e4-9b40-5457b3952ee2.png)

One shot of HE:
![screen022_640](https://cloud.githubusercontent.com/assets/3616568/6885440/020957ee-d629-11e4-8050-0f39fa7046f7.png)

If unit killed, the mark will be removed. This is because of engine.
![screen023_640](https://cloud.githubusercontent.com/assets/3616568/6885442/1a2f1886-d629-11e4-9170-cb068cd2c09f.png)
