### PR TITLE
Fix: Fixed id generation of crash sites

### DIFF
--- a/src/Geoscape/DogfightState.cpp
+++ b/src/Geoscape/DogfightState.cpp
@@ -1091,7 +1091,7 @@ void DogfightState::update()
 					_ufo->setAltitude("STR_GROUND");
 					if (_ufo->getCrashId() == 0)
 					{
-						_ufo->setCrashId(_game->getSavedGame()->getId("STR_CRASH_SITE"));
+						_ufo->setCrashId(_ufo->getId());
 					}
 				}
 			}


### PR DESCRIPTION
In vanilla Xcom each Crash site has number of corresponding UFO. 
For example: was UFO-3, then will be Crash site-3.
Therefore easy to track UFOs and his crash sites.

In regular OpenXcom numeration independent. This solution is awkward, uncomfortable.

This PR returns the vanilla behavior.

This change compatible backward and forward with regular OpenXcom.