### PR TITLE
Fix: Fixed id generation of alien bases

### DIFF
--- a/src/Geoscape/GeoscapeState.cpp
+++ b/src/Geoscape/GeoscapeState.cpp
@@ -1020,6 +1020,7 @@ void GeoscapeState::time10Minutes()
 							if (RNG::percent(50-((*j)->getDistance(*b) / range) * 50) && !(*b)->isDiscovered())
 							{
 								(*b)->setDiscovered(true);
+								(*b)->setId(_game->getSavedGame()->getId("STR_ALIEN_BASE"));
 							}
 						}
 					}
@@ -1710,6 +1711,7 @@ void GeoscapeState::time1Month()
 			if (!(*b)->isDiscovered())
 			{
 				(*b)->setDiscovered(true);
+				(*b)->setId(_game->getSavedGame()->getId("STR_ALIEN_BASE"));
 				popup(new AlienBaseState(*b, this));
 				break;
 			}

--- a/src/Savegame/AlienMission.cpp
+++ b/src/Savegame/AlienMission.cpp
@@ -611,7 +611,6 @@ void AlienMission::spawnAlienBase(const Globe &globe, Game &engine, int zone)
 	std::pair<double, double> pos = getLandPoint(globe, regionRules, zone);
 	AlienBase *ab = new AlienBase();
 	ab->setAlienRace(_race);
-	ab->setId(game.getId("STR_ALIEN_BASE"));
 	ab->setLongitude(pos.first);
 	ab->setLatitude(pos.second);
 	game.getAlienBases()->push_back(ab);


### PR DESCRIPTION
Opposite situation.

In this case vanilla Xcom has a bug.
Obviously, numeration of detected Alien bases must be performed in order of detection but not in order of foundation by aliens (not vanilla, but logical;)

Most voted for "Numbering of detected alien bases should be in order of discovering by Xcom forces."
http://openxcom.org/forum/index.php/topic,2799.msg29677.html

This change compatible backward and forward with regular OpenXcom.