### PR TITLE
Feature: Unhardcoded first turn when AI can use grenades, launchers etc

### DIFF
--- a/src/Battlescape/AlienBAIState.cpp
+++ b/src/Battlescape/AlienBAIState.cpp
@@ -52,7 +52,7 @@ namespace OpenXcom
  * @param node Pointer to the node the unit originates from.
  */
 AlienBAIState::AlienBAIState(SavedBattleGame *save, BattleUnit *unit, Node *node) : BattleAIState(save, unit), _aggroTarget(0), _knownEnemies(0), _visibleEnemies(0), _spottingEnemies(0),
-																				_escapeTUs(0), _ambushTUs(0), _reserveTUs(0), _rifle(false), _melee(false), _blaster(false),
+																				_escapeTUs(0), _ambushTUs(0), _reserveTUs(0), _rifle(false), _melee(false), _blaster(false), _grenade(false),
 																				_didPsi(false), _AIMode(AI_PATROL), _closestDist(100), _fromNode(node), _toNode(0)
 {
 	_traceAI = Options::traceAI;
@@ -187,10 +187,12 @@ void AlienBAIState::think(BattleAction *action)
 		Log(LOG_INFO) << "Currently using " << AIMode << " behaviour";
 	}
 
+	Ruleset *ruleset = _save->getBattleState()->getGame()->getRuleset();
 	if (action->weapon)
 	{
 		RuleItem *rule = action->weapon->getRules();
-		if (!rule->isWaterOnly() || _save->getDepth() != 0)
+		if (_save->getTurn() >= rule->getAIUseDelay(ruleset)
+			&& (!rule->isWaterOnly() || _save->getDepth() != 0))
 		{
 			if (rule->getBattleType() == BT_FIREARM)
 			{
@@ -217,6 +219,9 @@ void AlienBAIState::think(BattleAction *action)
 		}
 	}
 
+	BattleItem *grenade = _unit->getGrenadeFromBelt();
+	_grenade = grenade != 0 && _save->getTurn() >= grenade->getRules()->getAIUseDelay(ruleset);
+
 	if (_spottingEnemies && !_escapeTUs)
 	{
 		setupEscape();
@@ -230,7 +235,7 @@ void AlienBAIState::think(BattleAction *action)
 	setupAttack();
 	setupPatrol();
 
-	if (_psiAction->type != BA_NONE && !_didPsi)
+	if (_psiAction->type != BA_NONE && !_didPsi && _save->getTurn() >= ruleset->getAIUseDelayPsionic())
 	{
 		_didPsi = true;
 		action->type = _psiAction->type;
@@ -723,8 +728,7 @@ void AlienBAIState::setupAttack()
 		{
 			selectMeleeOrRanged();
 		}
-
-		if (_unit->getGrenadeFromBelt())
+		if (_grenade)
 		{
 			grenadeAction();
 		}
@@ -1497,9 +1501,6 @@ bool AlienBAIState::findFirePoint()
  */
 int AlienBAIState::explosiveEfficacy(Position targetPos, BattleUnit *attackingUnit, int radius, int diff, bool grenade) const
 {
-	// i hate the player and i want him dead, but i don't want to piss him off.
-	if (_save->getTurn() < 3)
-		return 0;
 	if (diff == -1)
 	{
 		diff = (int)(_save->getBattleState()->getGame()->getSavedGame()->getDifficulty());
@@ -2125,10 +2126,6 @@ void AlienBAIState::selectMeleeOrRanged()
  */
 bool AlienBAIState::getNodeOfBestEfficacy(BattleAction *action)
 {
-	// i hate the player and i want him dead, but i don't want to piss him off.
-	if (_save->getTurn() < 3)
-		return false;
-
 	int bestScore = 2;
 	Position originVoxel = _save->getTileEngine()->getSightOriginVoxel(_unit);
 	Position targetVoxel;

--- a/src/Battlescape/AlienBAIState.h
+++ b/src/Battlescape/AlienBAIState.h
@@ -42,7 +42,7 @@ protected:
 	int _knownEnemies, _visibleEnemies, _spottingEnemies;
 	int _escapeTUs, _ambushTUs, _reserveTUs;
 	BattleAction *_escapeAction, *_ambushAction, *_attackAction, *_patrolAction, *_psiAction;
-	bool _rifle, _melee, _blaster;
+	bool _rifle, _melee, _blaster, _grenade;
 	bool _traceAI, _didPsi;
 	int _AIMode, _intelligence, _closestDist;
 	Node *_fromNode, *_toNode;

--- a/src/Battlescape/TileEngine.cpp
+++ b/src/Battlescape/TileEngine.cpp
@@ -46,6 +46,7 @@
 #include "../Ruleset/Ruleset.h"
 #include "../Resource/ResourcePack.h"
 #include "Pathfinding.h"
+#include "../Engine/Game.h"
 #include "../Engine/Options.h"
 #include "ProjectileFlyBState.h"
 #include "MeleeAttackBState.h"
@@ -1001,6 +1002,14 @@ bool TileEngine::tryReaction(BattleUnit *unit, BattleUnit *target, int attackTyp
 	{
 		return false;
 	}
+
+	// check restrictions for aliens
+	if (unit->getFaction() == FACTION_HOSTILE &&
+		_save->getTurn() < action.weapon->getRules()->getAIUseDelay(_save->getBattleState()->getGame()->getRuleset()))
+	{
+		return false;
+	}
+
 	action.type = (BattleActionType)(attackType);
 	action.target = target->getPosition();
 	action.updateTU();

--- a/src/Ruleset/RuleItem.h
+++ b/src/Ruleset/RuleItem.h
@@ -30,6 +30,7 @@ namespace OpenXcom
 
 enum BattleType { BT_NONE, BT_FIREARM, BT_AMMO, BT_MELEE, BT_GRENADE, BT_PROXIMITYGRENADE, BT_MEDIKIT, BT_SCANNER, BT_MINDPROBE, BT_PSIAMP, BT_FLARE, BT_CORPSE };
 
+class Ruleset;
 class SurfaceSet;
 class Surface;
 class BattleUnit;
@@ -71,6 +72,7 @@ private:
 	int _recoveryPoints;
 	int _armor;
 	int _turretType;
+	int _aiUseDelay;
 	bool _recover, _liveAlien;
 	int _attraction;
 	bool _flatRate, _flatPrime, _flatThrow, _arcingShot;
@@ -235,6 +237,8 @@ public:
 	bool isRecoverable() const;
 	/// Gets the item's turret type.
 	int getTurretType() const;
+	/// Gets first turn when AI can use item.
+	int getAIUseDelay(Ruleset *ruleset = 0) const;
 	/// Checks if this a live alien.
 	bool isAlien() const;
 	/// Should we charge a flat rate?

--- a/src/Ruleset/Ruleset.cpp
+++ b/src/Ruleset/Ruleset.cpp
@@ -79,6 +79,7 @@ namespace OpenXcom
  */
 Ruleset::Ruleset() :
 	_maxViewDistance(20), _maxDarknessToSeeUnits(9), _costSoldier(0), _costEngineer(0), _costScientist(0), _timePersonnel(0), _initialFunding(0),
+	_aiUseDelayBlaster(3), _aiUseDelayFirearm(0), _aiUseDelayGrenade(3), _aiUseDelayMelee(0), _aiUseDelayPsionic(0),
 	_startingTime(6, 1, 1, 1999, 12, 0, 0), _modIndex(0), _facilityListOrder(0), _craftListOrder(0), _itemListOrder(0),
 	_researchListOrder(0),  _manufactureListOrder(0), _ufopaediaListOrder(0), _invListOrder(0)
 {
@@ -559,6 +560,15 @@ void Ruleset::loadFile(const std::string &filename)
 	_timePersonnel = doc["timePersonnel"].as<int>(_timePersonnel);
 	_initialFunding = doc["initialFunding"].as<int>(_initialFunding);
 	_alienFuel = doc["alienFuel"].as<std::string>(_alienFuel);
+	if (doc["ai"])
+	{
+		YAML::Node &nodeAI = doc["ai"];
+		_aiUseDelayBlaster = nodeAI["useDelayBlaster"].as<int>(_aiUseDelayBlaster);
+		_aiUseDelayFirearm = nodeAI["useDelayFirearm"].as<int>(_aiUseDelayFirearm);
+		_aiUseDelayGrenade = nodeAI["useDelayGrenade"].as<int>(_aiUseDelayGrenade);
+		_aiUseDelayMelee   = nodeAI["useDelayMelee"].as<int>(_aiUseDelayMelee);
+		_aiUseDelayPsionic = nodeAI["useDelayPsionic"].as<int>(_aiUseDelayPsionic);
+	}
 	for (YAML::const_iterator i = doc["ufoTrajectories"].begin(); i != doc["ufoTrajectories"].end(); ++i)
 	{
 		UfoTrajectory *rule = loadRule(*i, &_ufoTrajectories, 0, "id");

--- a/src/Ruleset/Ruleset.h
+++ b/src/Ruleset/Ruleset.h
@@ -113,6 +113,7 @@ protected:
 	RuleGlobe *_globe;
 	int _maxViewDistance, _maxDarknessToSeeUnits;
 	int _costSoldier, _costEngineer, _costScientist, _timePersonnel, _initialFunding;
+	int _aiUseDelayBlaster, _aiUseDelayFirearm, _aiUseDelayGrenade, _aiUseDelayMelee, _aiUseDelayPsionic;
 	std::string _alienFuel;
 	YAML::Node _startingBase;
 	GameTime _startingTime;
@@ -213,6 +214,16 @@ public:
 	int getScientistCost() const;
 	/// Gets the transfer time of personnel.
 	int getPersonnelTime() const;
+	/// Gets first turn when AI can use Blaster launcher.
+	int getAIUseDelayBlaster() const  {return _aiUseDelayBlaster;}
+	/// Gets first turn when AI can use firearms.
+	int getAIUseDelayFirearm() const  {return _aiUseDelayFirearm;}
+	/// Gets first turn when AI can use grenades.
+	int getAIUseDelayGrenade() const  {return _aiUseDelayGrenade;}
+	/// Gets first turn when AI can use martial arts.
+	int getAIUseDelayMelee() const    {return _aiUseDelayMelee;}
+	/// Gets first turn when AI can use psionic abilities.
+	int getAIUseDelayPsionic() const  {return _aiUseDelayPsionic;}
 	/// Gets the ruleset for a specific research project.
 	RuleResearch *getResearch (const std::string &id) const;
 	/// Gets the list of all research projects.


### PR DESCRIPTION
The "useDelay" rule can be global:
```
ai:
  useDelayBlaster: 3
  useDelayFirearm: 0
  useDelayGrenade: 3
  useDelayMelee: 0
  useDelayPsionic: 0
```
and local:
```
items:
  -type: STR_ITEM
    ai:
      useDelay: 3
```
By default local value is -1, global value is 3 for Blaster launcher and all grenades and 0 for other weapons.
If you set local value >= 0, then local value will be override the global rule for this item.

These rules works even during reaction fire.